### PR TITLE
Correction: SH_BAS2 => SH_BAS1 to match the instructions at top of file

### DIFF
--- a/EVShield_examples/bump_count/bump_count.ino
+++ b/EVShield_examples/bump_count/bump_count.ino
@@ -65,7 +65,7 @@ setup()
     //
     //  initialize the touch sensor, and tell where it is connected.
     //
-    touch1.init( &evshield, SH_BAS2);
+    touch1.init( &evshield, SH_BAS1);
 
 
     Serial.println("setup done");


### PR DESCRIPTION
Instructions shown in file: 

```
// setup for this example:
// attach external power to evshield.
// attach NXT Touch Sensor to Port BAS1
// Open the Serial terminal to view.
```
