### PR TITLE
support timing on Arduino 101

### DIFF
--- a/BaseI2CDevice.cpp
+++ b/BaseI2CDevice.cpp
@@ -21,7 +21,11 @@
 */
 
 #include "BaseI2CDevice.h"
-#include "MsTimer2.h"
+#if defined(ARDUINO_ARC32_TOOLS)
+  #include "CurieTimerOne.h"
+#else
+  #include "MsTimer2.h"
+#endif
 #include <Wire.h>
 
 extern "C" {
@@ -77,7 +81,11 @@ uint8_t* BaseI2CDevice::readRegisters(
   uint8_t  buffer_length,    // (optional) length of user-supplied buffer
   bool     clear_buffer)    // should we zero out the buffer first? (optional)
 {
-  MsTimer2::reset();
+  #if defined(ARDUINO_ARC32_TOOLS)
+    CurieTimerOne.rdRstTickCount();
+  #else
+    MsTimer2::reset();
+  #endif
   if (!buffer)
   {
     buffer = _buffer;
@@ -119,7 +127,11 @@ uint8_t* BaseI2CDevice::readRegisters(
 
     _write_error_code = Wire.endTransmission();
         
-  MsTimer2::reset();
+  #if defined(ARDUINO_ARC32_TOOLS)
+    CurieTimerOne.rdRstTickCount();
+  #else
+    MsTimer2::reset();
+  #endif
   return buffer;
 }
 
@@ -167,7 +179,11 @@ bool BaseI2CDevice::writeRegisters(
   uint8_t  bytes_to_write,   // number of bytes to write
   uint8_t* buffer)    // optional user-supplied buffer
 {
-  MsTimer2::reset();
+  #if defined(ARDUINO_ARC32_TOOLS)
+    CurieTimerOne.rdRstTickCount();
+  #else
+    MsTimer2::reset();
+  #endif
   if (!buffer)
   {
     buffer = _buffer;
@@ -193,7 +209,11 @@ bool BaseI2CDevice::writeRegisters(
 
   _write_error_code = Wire.endTransmission();
 
-  MsTimer2::reset();
+  #if defined(ARDUINO_ARC32_TOOLS)
+    CurieTimerOne.rdRstTickCount();
+  #else
+    MsTimer2::reset();
+  #endif
   return _write_error_code == 0;  // 0 indicates success
 }
 

--- a/MsTimer2.cpp
+++ b/MsTimer2.cpp
@@ -148,14 +148,16 @@ void MsTimer2::_overflow() {
 	}
 }
 
-ISR(TIMER2_OVF_vect) {
-#if defined (__AVR_ATmega168__) || defined (__AVR_ATmega48__) || defined (__AVR_ATmega88__) || defined (__AVR_ATmega328P__) || (__AVR_ATmega1280__)
-	TCNT2 = MsTimer2::tcnt2;
-#elif defined (__AVR_ATmega128__)
-	TCNT2 = MsTimer2::tcnt2;
-#elif defined (__AVR_ATmega8__)
-	TCNT2 = MsTimer2::tcnt2;
-#endif
-	MsTimer2::_overflow();
-}
+#if defined(__AVR__)
+	ISR(TIMER2_OVF_vect) {
+	#if defined (__AVR_ATmega168__) || defined (__AVR_ATmega48__) || defined (__AVR_ATmega88__) || defined (__AVR_ATmega328P__) || (__AVR_ATmega1280__)
+		TCNT2 = MsTimer2::tcnt2;
+	#elif defined (__AVR_ATmega128__)
+		TCNT2 = MsTimer2::tcnt2;
+	#elif defined (__AVR_ATmega8__)
+		TCNT2 = MsTimer2::tcnt2;
+	#endif
+		MsTimer2::_overflow();
+	}
 
+#endif

--- a/MsTimer2.h
+++ b/MsTimer2.h
@@ -1,7 +1,9 @@
 #ifndef MsTimer2_h
 #define MsTimer2_h
 
-#include <avr/interrupt.h>
+#if defined(__AVR__)
+  #include <avr/interrupt.h>
+#endif
 
 namespace MsTimer2 {
 	extern unsigned long msecs;

--- a/SHDefines.h
+++ b/SHDefines.h
@@ -41,6 +41,9 @@
   #endif
 
 #endif
+#if defined(ARDUINO_ARC32_TOOLS)
+  #define MODEL_EVSHIELD_D
+#endif
 
 
 /**


### PR DESCRIPTION
The [MsTimer2](http://playground.arduino.cc/Main/MsTimer2) library (using timer2 with hard-coded 1ms resolution) 
supports ATmega1280, ATmega328, ATmega48/88/168 and ATmega128/8. 
For the Arduino/Genuino 101 we need to use the [CurieTimerOne](https://www.arduino.cc/en/Reference/CurieTimerOne) library.
