### PR TITLE
update waitForButtonPress led_pattern default value to align with doucmentation

### DIFF
--- a/EVShield.h
+++ b/EVShield.h
@@ -730,7 +730,7 @@ public:
   1 to brighten/lighten LED with breathing pattern (default).
   2 to brighten/lighten LED with heart beat pattern.
   */
-  void waitForButtonPress(uint8_t btn, uint8_t led_pattern=0);
+  void waitForButtonPress(uint8_t btn, uint8_t led_pattern=1);
   
 
   /**


### PR DESCRIPTION
The EVShield documentation specifies the default led_pattern for waitForButtonPress is "to brighten/lighten LED with breathing pattern." The default value was 0 (LED off), now it has been update to reflect the documentation.
