### PR TITLE
add sensor class prefix where missing

### DIFF
--- a/EVShield_examples/ev3us_runaway/ev3us_runaway.ino
+++ b/EVShield_examples/ev3us_runaway/ev3us_runaway.ino
@@ -23,7 +23,7 @@ http://www.openelectrons.com/docs/viewdoc/25
 #include <Wire.h>
 #include <EVShield.h>
 //#include <EVShieldAGS.h>
-#include <EV3Ultrasonic.h>
+#include <EVs_EV3Ultrasonic.h>
 
 
 // setup for this example:
@@ -39,7 +39,7 @@ EVShield          evshield(0x34,0x36);
 //
 //  Declare our sensor for use in this program
 //
-EV3Ultrasonic us1;
+EVs_EV3Ultrasonic us1;
 
 void
 setup()

--- a/EVShield_examples/gyro_square/gyro_square.ino
+++ b/EVShield_examples/gyro_square/gyro_square.ino
@@ -23,7 +23,7 @@ http://www.openelectrons.com/docs/viewdoc/25
 #include <Wire.h>
 #include <EVShield.h>
 #include <EVShieldAGS.h>
-#include <EV3Gyro.h>
+#include <EVs_EV3Gyro.h>
 
 
 // setup for this example:
@@ -39,7 +39,7 @@ EVShield          evshield(0x34,0x36);
 //
 //  Declare our sensor for use in this program
 //
-EV3Gyro gyro1;
+EVs_EV3Gyro gyro1;
 
 void
 setup()

--- a/EVShield_examples/touch_runaway/touch_runaway.ino
+++ b/EVShield_examples/touch_runaway/touch_runaway.ino
@@ -23,7 +23,7 @@ http://www.openelectrons.com/docs/viewdoc/25
 #include <Wire.h>
 #include <EVShield.h>
 //#include <EVShieldAGS.h>
-#include <EV3Touch.h>
+#include <EVs_EV3Touch.h>
 
 
 // setup for this example:
@@ -39,7 +39,7 @@ EVShield          evshield(0x34,0x36);
 //
 //  Declare our sensor for use in this program
 //
-EV3Touch touch1;
+EVs_EV3Touch touch1;
 
 void
 setup()

--- a/EVShield_tests/PFMate/PFMate.ino
+++ b/EVShield_tests/PFMate/PFMate.ino
@@ -20,7 +20,7 @@ http://www.openelectrons.com/docs/viewdoc/25
 
 #include <Wire.h>
 #include <EVShield.h>
-#include <PFMate.h>
+#include <EVs_PFMate.h>
 
 // setup for this example:
 // attach PFMate to Port BAS1
@@ -35,7 +35,7 @@ EVShield    evshield (0x34 ,0x36);
 // declare the i2c devices used on EVShield(s).
 //
 
-PFMate pfmate (0x48);
+EVs_PFMate pfmate (0x48);
 
 void setup()
 {


### PR DESCRIPTION
The EV3 sensor files and classes are prefixed with "EVs_"
