### PR TITLE
Clean up code and update documentation

### DIFF
--- a/EVs_EV3SensorMux.h
+++ b/EVs_EV3SensorMux.h
@@ -27,28 +27,45 @@
 #ifndef	EV3_SENSOR_MUX_H
 #define	EV3_SENSOR_MUX_H
 
-#define	ESA_Command	0x41
+#define	ESA_Command 0x41
 
-#include	"EVShieldI2C.h"
-	/** @brief This class 
- 	  * interfaces with sensor attached to NXShield */
-class EVs_EV3SensorMux : public EVShieldI2C
-{
+#include "EVShieldI2C.h"
+/** 
+ * @brief This class 
+ * interfaces with sensors attached to NXShield 
+ */
+class EVs_EV3SensorMux : public EVShieldI2C {
 public:
-	/** Constructor for the class; may supply an optional custom i2c address 	*/
-	EVs_EV3SensorMux(uint8_t i2c_address = 0x32);
-	/** Write a command byte at the command register of the device */  
-	uint8_t	issueCommand(char command);
-	/** The EV3 sensors have different modes, you can change the mode of attached sensor with this function. To learn what all modes are availale, refer to LEGO's documentation */
-    uint8_t	setMode(char newMode);
-    /** it is possible to read back the mode that was set last time.
-    use getMode to read the current mode */
-    byte	getMode( );
-    /** Read the value from the sensor attached to EVs_EV3SensorMux
-    */
+    /** 
+     * Constructor for the class. 
+     * @param i2c_address Optional custom i2c address.
+     */
+    EVs_EV3SensorMux(uint8_t i2c_address = 0x32);
+    
+    /** 
+     * Writes a command byte at the command register of the device.
+     * @param command The command byte to be written.
+     */  
+    uint8_t issueCommand(char command);
+    
+    /** 
+     * The EV3 sensors have different modes, 
+     * you can change the mode of attached sensor with this function. 
+     * To learn what all modes are availale, refer to LEGO's documentation. 
+     * @param newMode The mode the sensor is set to.
+     */
+    uint8_t setMode(char newMode);
+    
+    /** 
+     * It's possible to read back the mode that was set last time.
+     * Use getMode to read the current mode.
+     */
+    byte getMode();
+    
+    /** 
+     * Reads the value from the sensor attached to EVs_EV3SensorMux
+     */
     int readValue();
-
-
 };
 
 #endif


### PR DESCRIPTION
The indentation was all over the place, and the documentation didn't document the input arguments.

Question is, if all it has is public methods, wouldn't it be better to change it to a struct instead?
In C++, structs are just classes with public access by default.
