### PR TITLE
Cleaned up debugging function in EVs_EV3Color

### DIFF
--- a/EVs_EV3Color.cpp
+++ b/EVs_EV3Color.cpp
@@ -31,7 +31,7 @@ float EVs_EV3Color::getVal()
 {
     uint16_t l, m;
     float result;
-    readAndPrint(0x81+m_offset, 10);
+    //readAndPrint(0x81+m_offset, 10);
     result = readValue();
     return (result);
 }


### PR DESCRIPTION
EVS_EV3Color::getVal() was printing to serial a bunch of data that appears only useful for debugging purposes. With no way to turn it off .

Suggest removing readAndPrint function or adding a global setting that allows for debugging code within EVShield.